### PR TITLE
Milestone: can construct coding challenge solution

### DIFF
--- a/can-construct/can_construct.py
+++ b/can-construct/can_construct.py
@@ -1,16 +1,17 @@
-def can_construct(target_string, word_bank):
+def can_construct(target_string, word_bank, memo={}):
   '''
     Returns a boolean indicating whether or not the `target` 
     can be constructed by concatenating elements of the `word_bank` array.
   '''
-
-  if target_string == '':
-    return True
+  if target_string in memo: return memo[target_string]
+  if target_string == '': return True
 
   for word in word_bank:
-    if target_string[0:len(word)] == word:
+    if target_string.startswith(word):
       new_target_str = target_string[len(word):]
       if can_construct(new_target_str, word_bank) == True:
+        memo[target_string] = True
         return True
 
+  memo[target_string] = False
   return False

--- a/can-construct/can_construct.py
+++ b/can-construct/can_construct.py
@@ -1,0 +1,16 @@
+def can_construct(target_string, word_bank):
+  '''
+    Returns a boolean indicating whether or not the `target` 
+    can be constructed by concatenating elements of the `word_bank` array.
+  '''
+
+  if target_string == '':
+    return True
+
+  for word in word_bank:
+    if target_string[0:len(word)] == word:
+      new_target_str = target_string[len(word):]
+      if can_construct(new_target_str, word_bank) == True:
+        return True
+
+  return False

--- a/can-construct/can_construct_test.py
+++ b/can-construct/can_construct_test.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+from can_construct import can_construct
+
+class BestSumTest(TestCase):
+    def test_can_construct_abcdef(self):
+      assert can_construct('abcdef', ['ab', 'abc', 'cd', 'def', 'abcd']) == True
+
+    def test_can_construct_skateboard(self):
+      assert can_construct('skateboard', ['bo', 'rd', 'ate', 't', 'ska', 'sk', 'boar']) == False
+
+    def test_can_construct_enterapotentpot(self):
+      assert can_construct('enterapotentpot', ['a', 'p', 'ent', 'enter', 'ot', 'o', 't']) == True
+
+    def test_can_construct_longeef(self):
+      assert can_construct('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeef', ['e', 'ee', 'eee', 'eeee', 'eeeee', 'eeeeee']) == False
+

--- a/can-construct/readme.md
+++ b/can-construct/readme.md
@@ -1,0 +1,15 @@
+## Can Construct Coding challenge
+> Write a function `can_construct` that takes in a target string and an array of strings as arguments. The function
+should return a boolean indicating whether or not the `target` can be constructed by concatenating elements of the `wordBank` array.
+
+## Constraints
+- You may use an element of the array as many times as needed.
+
+
+## Examples
+```Python
+  can_construct('abcdef', ['ab', 'abc', 'cd', 'def', 'abcd']) => True
+  can_construct('skateboard', ['bo', 'rd', 'ate', 't', 'ska', 'sk', 'boar']) => False
+  can_construct('enterapotentpot', ['a', 'p', 'ent', 'enter', 'ot', 'o', 't']) => True
+  can_construct('eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeef', ['e', 'ee', 'eee', 'eeee', 'eeeee', 'eeeeee']) => False
+```


### PR DESCRIPTION
## Changes in this pull request
> In this pull request I
- Added unit tests for the `can_construct` coding challenge
- Implemented a solution to solve the coding challenge below

> Write a function `can_construct` that takes in a target string and an array of strings as arguments. The function
should return a boolean indicating whether or not the `target` can be constructed by concatenating elements of the `word_bank` array.

## Examples
```Python
  can_construct('abcdef', ['ab', 'abc', 'cd', 'def', 'abcd']) => True
  can_construct('skateboard', ['bo', 'rd', 'ate', 't', 'ska', 'sk', 'boar']) => False
  can_construct('enterapotentpot', ['a', 'p', 'ent', 'enter', 'ot', 'o', 't']) => True
  can_construct('eeeeeeeeeeeeeeeeeeeeeeeef', ['e', 'ee', 'eee', 'eeee', 'eeeee', 'eeeeee']) => False
```